### PR TITLE
Convert specs to RSpec 2.14.8 syntax with Transpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "redis"
 

--- a/predictor.gemspec
+++ b/predictor.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "redis", ">= 3.0.0"
 
-  s.add_development_dependency "rspec", "~> 2.8.0"
+  s.add_development_dependency "rspec", ">= 2.14.0"
 
   s.files         = `git ls-files`.split("\n") - [".gitignore", ".rspec", ".travis.yml"]
   s.test_files    = `git ls-files -- spec/*`.split("\n")

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -13,27 +13,27 @@ describe Predictor::Base do
   describe "configuration" do
     it "should add an input_matrix by 'key'" do
       BaseRecommender.input_matrix(:myinput)
-      BaseRecommender.input_matrices.keys.should == [:myinput]
+      expect(BaseRecommender.input_matrices.keys).to eq([:myinput])
     end
 
     it "should retrieve an input_matrix on a new instance" do
       BaseRecommender.input_matrix(:myinput)
       sm = BaseRecommender.new
-      lambda{ sm.myinput }.should_not raise_error
+      expect{ sm.myinput }.not_to raise_error
     end
 
     it "should retrieve an input_matrix on a new instance and correctly overload respond_to?" do
       BaseRecommender.input_matrix(:myinput)
       sm = BaseRecommender.new
-      sm.respond_to?(:process!).should be_true
-      sm.respond_to?(:myinput).should be_true
-      sm.respond_to?(:fnord).should be_false
+      expect(sm.respond_to?(:process!)).to be_true
+      expect(sm.respond_to?(:myinput)).to be_true
+      expect(sm.respond_to?(:fnord)).to be_false
     end
 
     it "should retrieve an input_matrix on a new instance and intialize the correct class" do
       BaseRecommender.input_matrix(:myinput)
       sm = BaseRecommender.new
-      sm.myinput.should be_a(Predictor::InputMatrix)
+      expect(sm.myinput).to be_a(Predictor::InputMatrix)
     end
   end
 
@@ -42,8 +42,8 @@ describe Predictor::Base do
       BaseRecommender.input_matrix(:myfirstinput)
       BaseRecommender.input_matrix(:mysecondinput)
       sm = BaseRecommender.new
-      sm.myfirstinput.should_receive(:process_item!).with("fnorditem").and_return([["fooitem",0.5]])
-      sm.mysecondinput.should_receive(:process_item!).with("fnorditem").and_return([["fooitem",0.5]])
+      expect(sm.myfirstinput).to receive(:process_item!).with("fnorditem").and_return([["fooitem",0.5]])
+      expect(sm.mysecondinput).to receive(:process_item!).with("fnorditem").and_return([["fooitem",0.5]])
       sm.process_item!("fnorditem")
     end
 
@@ -51,8 +51,8 @@ describe Predictor::Base do
       BaseRecommender.input_matrix(:myfirstinput)
       BaseRecommender.input_matrix(:mysecondinput)
       sm = BaseRecommender.new
-      sm.myfirstinput.should_receive(:process_item!).and_return([["fooitem",0.5]])
-      sm.mysecondinput.should_receive(:process_item!).and_return([["fooitem",0.75], ["baritem", 1.0]])
+      expect(sm.myfirstinput).to receive(:process_item!).and_return([["fooitem",0.5]])
+      expect(sm.mysecondinput).to receive(:process_item!).and_return([["fooitem",0.75], ["baritem", 1.0]])
       sm.process_item!("fnorditem")
     end
 
@@ -60,8 +60,8 @@ describe Predictor::Base do
       BaseRecommender.input_matrix(:myfirstinput, :weight => 4.0)
       BaseRecommender.input_matrix(:mysecondinput)
       sm = BaseRecommender.new
-      sm.myfirstinput.should_receive(:process_item!).and_return([["fooitem",0.5]])
-      sm.mysecondinput.should_receive(:process_item!).and_return([["fooitem",0.75], ["baritem", 1.0]])
+      expect(sm.myfirstinput).to receive(:process_item!).and_return([["fooitem",0.5]])
+      expect(sm.mysecondinput).to receive(:process_item!).and_return([["fooitem",0.75], ["baritem", 1.0]])
       sm.process_item!("fnorditem")
     end
   end
@@ -73,8 +73,8 @@ describe Predictor::Base do
       sm = BaseRecommender.new
       sm.anotherinput.add_set('a', ["foo", "bar"])
       sm.yetanotherinput.add_set('b', ["fnord", "shmoo"])
-      sm.all_items.length.should == 4
-      sm.all_items.should include("foo", "bar", "fnord", "shmoo")
+      expect(sm.all_items.length).to eq(4)
+      expect(sm.all_items).to include("foo", "bar", "fnord", "shmoo")
     end
 
     it "should retrieve all items from all input matrices (uniquely)" do
@@ -83,8 +83,8 @@ describe Predictor::Base do
       sm = BaseRecommender.new
       sm.anotherinput.add_set('a', ["foo", "bar"])
       sm.yetanotherinput.add_set('b', ["fnord", "bar"])
-      sm.all_items.length.should == 3
-      sm.all_items.should include("foo", "bar", "fnord")
+      expect(sm.all_items.length).to eq(3)
+      expect(sm.all_items).to include("foo", "bar", "fnord")
     end
   end
 
@@ -95,8 +95,8 @@ describe Predictor::Base do
       sm = BaseRecommender.new
       sm.anotherinput.add_set('a', ["foo", "bar"])
       sm.yetanotherinput.add_set('b', ["fnord", "shmoo"])
-      sm.anotherinput.should_receive(:process!).exactly(1).times
-      sm.yetanotherinput.should_receive(:process!).exactly(1).times
+      expect(sm.anotherinput).to receive(:process!).exactly(1).times
+      expect(sm.yetanotherinput).to receive(:process!).exactly(1).times
       sm.process!
     end
   end
@@ -115,13 +115,13 @@ describe Predictor::Base do
       sm.tags.add_set('tag3', ["shmoo", "nada"])
       sm.process!
       predictions = sm.predictions_for('me', matrix_label: :users)
-      predictions.should == ["shmoo", "other", "nada"]
+      expect(predictions).to eq(["shmoo", "other", "nada"])
       predictions = sm.predictions_for(item_set: ["foo", "bar", "fnord"])
-      predictions.should == ["shmoo", "other", "nada"]
+      expect(predictions).to eq(["shmoo", "other", "nada"])
       predictions = sm.predictions_for('me', matrix_label: :users, offset: 1, limit: 1)
-      predictions.should == ["other"]
+      expect(predictions).to eq(["other"])
       predictions = sm.predictions_for('me', matrix_label: :users, offset: 1)
-      predictions.should == ["other", "nada"]
+      expect(predictions).to eq(["other", "nada"])
     end
 
     it "correctly normalizes predictions" do
@@ -141,24 +141,24 @@ describe Predictor::Base do
       sm.process!
 
       predictions = sm.predictions_for('user1', matrix_label: :users, with_scores: true, normalize: false)
-      predictions.should eq([["c3", 4.5]])
+      expect(predictions).to eq([["c3", 4.5]])
       predictions = sm.predictions_for('user2',  matrix_label: :users, with_scores: true, normalize: false)
-      predictions.should eq([["c1", 6.5], ["c2", 5.5]])
+      expect(predictions).to eq([["c1", 6.5], ["c2", 5.5]])
       predictions = sm.predictions_for('user1', matrix_label: :users, with_scores: true, normalize: true)
-      predictions[0][0].should eq("c3")
-      predictions[0][1].should be_within(0.001).of(0.592)
+      expect(predictions[0][0]).to eq("c3")
+      expect(predictions[0][1]).to be_within(0.001).of(0.592)
       predictions = sm.predictions_for('user2', matrix_label: :users, with_scores: true, normalize: true)
-      predictions[0][0].should eq("c2")
-      predictions[0][1].should be_within(0.001).of(1.065)
-      predictions[1][0].should eq("c1")
-      predictions[1][1].should be_within(0.001).of(0.764)
+      expect(predictions[0][0]).to eq("c2")
+      expect(predictions[0][1]).to be_within(0.001).of(1.065)
+      expect(predictions[1][0]).to eq("c1")
+      expect(predictions[1][1]).to be_within(0.001).of(0.764)
     end
   end
 
   describe "similarities_for(item_id)" do
     it "should not throw exception for non existing items" do
       sm = BaseRecommender.new
-      sm.similarities_for("not_existing_item").length.should == 0
+      expect(sm.similarities_for("not_existing_item").length).to eq(0)
     end
 
     it "correctly weighs and sums input matrices" do
@@ -176,10 +176,10 @@ describe Predictor::Base do
       sm.tags.add_set('tag2', ["c1", "c4"])
 
       sm.process!
-      sm.similarities_for("c1", with_scores: true).should eq([["c4", 6.5], ["c2", 2.0]])
-      sm.similarities_for("c2", with_scores: true).should eq([["c3", 4.0], ["c1", 2.0], ["c4", 1.5]])
-      sm.similarities_for("c3", with_scores: true).should eq([["c2", 4.0], ["c4", 0.5]])
-      sm.similarities_for("c4", with_scores: true, exclusion_set: ["c3"]).should eq([["c1", 6.5], ["c2", 1.5]])
+      expect(sm.similarities_for("c1", with_scores: true)).to eq([["c4", 6.5], ["c2", 2.0]])
+      expect(sm.similarities_for("c2", with_scores: true)).to eq([["c3", 4.0], ["c1", 2.0], ["c4", 1.5]])
+      expect(sm.similarities_for("c3", with_scores: true)).to eq([["c2", 4.0], ["c4", 0.5]])
+      expect(sm.similarities_for("c4", with_scores: true, exclusion_set: ["c3"])).to eq([["c1", 6.5], ["c2", 1.5]])
     end
   end
 
@@ -191,9 +191,9 @@ describe Predictor::Base do
       sm.set1.add_set "item1", ["foo", "bar"]
       sm.set1.add_set "item2", ["nada", "bar"]
       sm.set2.add_set "item3", ["bar", "other"]
-      sm.sets_for("bar").length.should == 3
-      sm.sets_for("bar").should include("item1", "item2", "item3")
-      sm.sets_for("other").should == ["item3"]
+      expect(sm.sets_for("bar").length).to eq(3)
+      expect(sm.sets_for("bar")).to include("item1", "item2", "item3")
+      expect(sm.sets_for("other")).to eq(["item3"])
     end
   end
 
@@ -202,8 +202,8 @@ describe Predictor::Base do
       BaseRecommender.input_matrix(:myfirstinput)
       BaseRecommender.input_matrix(:mysecondinput)
       sm = BaseRecommender.new
-      sm.myfirstinput.should_receive(:delete_item!).with("fnorditem")
-      sm.mysecondinput.should_receive(:delete_item!).with("fnorditem")
+      expect(sm.myfirstinput).to receive(:delete_item!).with("fnorditem")
+      expect(sm.mysecondinput).to receive(:delete_item!).with("fnorditem")
       sm.delete_item!("fnorditem")
     end
   end
@@ -216,9 +216,9 @@ describe Predictor::Base do
       sm.set1.add_set "item1", ["foo", "bar"]
       sm.set1.add_set "item2", ["nada", "bar"]
       sm.set2.add_set "item3", ["bar", "other"]
-      Predictor.redis.keys("#{sm.redis_prefix}:*").should_not be_empty
+      expect(Predictor.redis.keys("#{sm.redis_prefix}:*")).not_to be_empty
       sm.clean!
-      Predictor.redis.keys("#{sm.redis_prefix}:*").should be_empty
+      expect(Predictor.redis.keys("#{sm.redis_prefix}:*")).to be_empty
     end
   end
 end

--- a/spec/input_matrix_spec.rb
+++ b/spec/input_matrix_spec.rb
@@ -11,92 +11,92 @@ describe Predictor::InputMatrix do
   end
 
   it "should build the correct keys" do
-    @matrix.redis_key.should == "predictor-test:mymatrix"
+    expect(@matrix.redis_key).to eq("predictor-test:mymatrix")
   end
 
   it "should respond to add_set" do
-    @matrix.respond_to?(:add_set).should == true
+    expect(@matrix.respond_to?(:add_set)).to eq(true)
   end
 
   it "should respond to add_single" do
-    @matrix.respond_to?(:add_single).should == true
+    expect(@matrix.respond_to?(:add_single)).to eq(true)
   end
 
   it "should respond to similarities_for" do
-    @matrix.respond_to?(:similarities_for).should == true
+    expect(@matrix.respond_to?(:similarities_for)).to eq(true)
   end
 
   it "should respond to all_items" do
-    @matrix.respond_to?(:all_items).should == true
+    expect(@matrix.respond_to?(:all_items)).to eq(true)
   end
 
   describe "weight" do
     it "returns the weight configured or a default of 1" do
-      @matrix.weight.should == 1.0  # default weight
+      expect(@matrix.weight).to eq(1.0)  # default weight
       matrix = Predictor::InputMatrix.new(redis_prefix: "predictor-test", key: "mymatrix", weight: 5.0)
-      matrix.weight.should == 5.0
+      expect(matrix.weight).to eq(5.0)
     end
   end
 
   describe "add_set" do
     it "adds each member of the set to the 'all_items' set" do
-      @matrix.all_items.should_not include("foo", "bar", "fnord", "blubb")
+      expect(@matrix.all_items).not_to include("foo", "bar", "fnord", "blubb")
       @matrix.add_set "item1", ["foo", "bar", "fnord", "blubb"]
-      @matrix.all_items.should include("foo", "bar", "fnord", "blubb")
+      expect(@matrix.all_items).to include("foo", "bar", "fnord", "blubb")
     end
 
     it "adds each member of the set to the key's 'sets' set" do
-      @matrix.items_for("item1").should_not include("foo", "bar", "fnord", "blubb")
+      expect(@matrix.items_for("item1")).not_to include("foo", "bar", "fnord", "blubb")
       @matrix.add_set "item1", ["foo", "bar", "fnord", "blubb"]
-      @matrix.items_for("item1").should include("foo", "bar", "fnord", "blubb")
+      expect(@matrix.items_for("item1")).to include("foo", "bar", "fnord", "blubb")
     end
 
     it "adds the key to each set member's 'items' set" do
-      @matrix.sets_for("foo").should_not include("item1")
-      @matrix.sets_for("bar").should_not include("item1")
-      @matrix.sets_for("fnord").should_not include("item1")
-      @matrix.sets_for("blubb").should_not include("item1")
+      expect(@matrix.sets_for("foo")).not_to include("item1")
+      expect(@matrix.sets_for("bar")).not_to include("item1")
+      expect(@matrix.sets_for("fnord")).not_to include("item1")
+      expect(@matrix.sets_for("blubb")).not_to include("item1")
       @matrix.add_set "item1", ["foo", "bar", "fnord", "blubb"]
-      @matrix.sets_for("foo").should include("item1")
-      @matrix.sets_for("bar").should include("item1")
-      @matrix.sets_for("fnord").should include("item1")
-      @matrix.sets_for("blubb").should include("item1")
+      expect(@matrix.sets_for("foo")).to include("item1")
+      expect(@matrix.sets_for("bar")).to include("item1")
+      expect(@matrix.sets_for("fnord")).to include("item1")
+      expect(@matrix.sets_for("blubb")).to include("item1")
     end
   end
 
   describe "add_set!" do
     it "calls add_set and process_item! for each item" do
-      @matrix.should_receive(:add_set).with("item1", ["foo", "bar"])
-      @matrix.should_receive(:process_item!).with("foo")
-      @matrix.should_receive(:process_item!).with("bar")
+      expect(@matrix).to receive(:add_set).with("item1", ["foo", "bar"])
+      expect(@matrix).to receive(:process_item!).with("foo")
+      expect(@matrix).to receive(:process_item!).with("bar")
       @matrix.add_set! "item1", ["foo", "bar"]
     end
   end
 
   describe "add_single" do
     it "adds the item to the 'all_items' set" do
-      @matrix.all_items.should_not include("foo")
+      expect(@matrix.all_items).not_to include("foo")
       @matrix.add_single "item1", "foo"
-      @matrix.all_items.should include("foo")
+      expect(@matrix.all_items).to include("foo")
     end
 
     it "adds the item to the key's 'sets' set" do
-      @matrix.items_for("item1").should_not include("foo")
+      expect(@matrix.items_for("item1")).not_to include("foo")
       @matrix.add_single "item1", "foo"
-      @matrix.items_for("item1").should include("foo")
+      expect(@matrix.items_for("item1")).to include("foo")
     end
 
     it "adds the key to the item's 'items' set" do
-      @matrix.sets_for("foo").should_not include("item1")
+      expect(@matrix.sets_for("foo")).not_to include("item1")
       @matrix.add_single "item1", "foo"
-      @matrix.sets_for("foo").should include("item1")
+      expect(@matrix.sets_for("foo")).to include("item1")
     end
   end
 
   describe "add_single!" do
     it "calls add_single and process_item! for the item" do
-      @matrix.should_receive(:add_single).with("item1", "foo")
-      @matrix.should_receive(:process_item!).with("foo")
+      expect(@matrix).to receive(:add_single).with("item1", "foo")
+      expect(@matrix).to receive(:process_item!).with("foo")
       @matrix.add_single! "item1", "foo"
     end
   end
@@ -106,18 +106,18 @@ describe Predictor::InputMatrix do
       @matrix.add_set "item1", ["foo", "bar", "fnord", "blubb"]
       @matrix.add_set "item2", ["foo", "bar", "snafu", "nada"]
       @matrix.add_set "item3", ["nada"]
-      @matrix.all_items.should include("foo", "bar", "fnord", "blubb", "snafu", "nada")
-      @matrix.all_items.length.should == 6
+      expect(@matrix.all_items).to include("foo", "bar", "fnord", "blubb", "snafu", "nada")
+      expect(@matrix.all_items.length).to eq(6)
     end
   end
 
   describe "items_for" do
     it "returns the items in the given set ID" do
       @matrix.add_set "item1", ["foo", "bar", "fnord", "blubb"]
-      @matrix.items_for("item1").should include("foo", "bar", "fnord", "blubb")
+      expect(@matrix.items_for("item1")).to include("foo", "bar", "fnord", "blubb")
       @matrix.add_set "item2", ["foo", "bar", "snafu", "nada"]
-      @matrix.items_for("item2").should include("foo", "bar", "snafu", "nada")
-      @matrix.items_for("item1").should_not include("snafu", "nada")
+      expect(@matrix.items_for("item2")).to include("foo", "bar", "snafu", "nada")
+      expect(@matrix.items_for("item1")).not_to include("snafu", "nada")
     end
   end
 
@@ -125,8 +125,8 @@ describe Predictor::InputMatrix do
     it "returns the set IDs the given item is in" do
       @matrix.add_set "item1", ["foo", "bar", "fnord", "blubb"]
       @matrix.add_set "item2", ["foo", "bar", "snafu", "nada"]
-      @matrix.sets_for("foo").should include("item1", "item2")
-      @matrix.sets_for("snafu").should == ["item2"]
+      expect(@matrix.sets_for("foo")).to include("item1", "item2")
+      expect(@matrix.sets_for("snafu")).to eq(["item2"])
     end
   end
 
@@ -135,11 +135,11 @@ describe Predictor::InputMatrix do
       @matrix.add_set "item1", ["foo", "bar", "fnord", "blubb"]
       @matrix.add_set "item2", ["foo", "bar", "snafu", "nada"]
       @matrix.add_set "item3", ["nada", "other"]
-      @matrix.related_items("bar").should include("foo", "fnord", "blubb", "snafu", "nada")
-      @matrix.related_items("bar").length.should == 5
-      @matrix.related_items("other").should == ["nada"]
-      @matrix.related_items("snafu").should include("foo", "bar", "nada")
-      @matrix.related_items("snafu").length.should == 3
+      expect(@matrix.related_items("bar")).to include("foo", "fnord", "blubb", "snafu", "nada")
+      expect(@matrix.related_items("bar").length).to eq(5)
+      expect(@matrix.related_items("other")).to eq(["nada"])
+      expect(@matrix.related_items("snafu")).to include("foo", "bar", "nada")
+      expect(@matrix.related_items("snafu").length).to eq(3)
     end
   end
 
@@ -147,8 +147,8 @@ describe Predictor::InputMatrix do
     it "should calculate the correct similarity between two items" do
       add_two_item_test_data!(@matrix)
       @matrix.process!
-      @matrix.similarity("fnord", "blubb").should == 0.4
-      @matrix.similarity("blubb", "fnord").should == 0.4
+      expect(@matrix.similarity("fnord", "blubb")).to eq(0.4)
+      expect(@matrix.similarity("blubb", "fnord")).to eq(0.4)
     end
   end
 
@@ -157,18 +157,18 @@ describe Predictor::InputMatrix do
       add_three_item_test_data!(@matrix)
       @matrix.process!
       res = @matrix.similarities_for("fnord", with_scores: true)
-      res.length.should == 2
-      res[0].should == ["shmoo", 0.75]
-      res[1].should == ["blubb", 0.4]
+      expect(res.length).to eq(2)
+      expect(res[0]).to eq(["shmoo", 0.75])
+      expect(res[1]).to eq(["blubb", 0.4])
     end
 
     it "should calculate all similarities for an item (2/3)" do
       add_three_item_test_data!(@matrix)
       @matrix.process!
       res = @matrix.similarities_for("shmoo", with_scores: true)
-      res.length.should == 2
-      res[0].should == ["fnord", 0.75]
-      res[1].should == ["blubb", 0.2]
+      expect(res.length).to eq(2)
+      expect(res[0]).to eq(["fnord", 0.75])
+      expect(res[1]).to eq(["blubb", 0.2])
     end
 
 
@@ -176,9 +176,9 @@ describe Predictor::InputMatrix do
       add_three_item_test_data!(@matrix)
       @matrix.process!
       res = @matrix.similarities_for("blubb", with_scores: true)
-      res.length.should == 2
-      res[0].should == ["fnord", 0.4]
-      res[1].should == ["shmoo", 0.2]
+      expect(res.length).to eq(2)
+      expect(res[0]).to eq(["fnord", 0.4])
+      expect(res[1]).to eq(["shmoo", 0.2])
     end
   end
 
@@ -191,31 +191,31 @@ describe Predictor::InputMatrix do
     end
 
     it "should delete the item from sets it is in" do
-      @matrix.items_for("item1").should include("bar")
-      @matrix.items_for("item2").should include("bar")
-      @matrix.sets_for("bar").should include("item1", "item2")
+      expect(@matrix.items_for("item1")).to include("bar")
+      expect(@matrix.items_for("item2")).to include("bar")
+      expect(@matrix.sets_for("bar")).to include("item1", "item2")
       @matrix.delete_item!("bar")
-      @matrix.items_for("item1").should_not include("bar")
-      @matrix.items_for("item2").should_not include("bar")
-      @matrix.sets_for("bar").should be_empty
+      expect(@matrix.items_for("item1")).not_to include("bar")
+      expect(@matrix.items_for("item2")).not_to include("bar")
+      expect(@matrix.sets_for("bar")).to be_empty
     end
 
     it "should delete the cached similarities for the item" do
-      @matrix.similarities_for("bar").should_not be_empty
+      expect(@matrix.similarities_for("bar")).not_to be_empty
       @matrix.delete_item!("bar")
-      @matrix.similarities_for("bar").should be_empty
+      expect(@matrix.similarities_for("bar")).to be_empty
     end
 
     it "should delete the item from other cached similarities" do
-      @matrix.similarities_for("foo").should include("bar")
+      expect(@matrix.similarities_for("foo")).to include("bar")
       @matrix.delete_item!("bar")
-      @matrix.similarities_for("foo").should_not include("bar")
+      expect(@matrix.similarities_for("foo")).not_to include("bar")
     end
 
     it "should delete the item from the all_items set" do
-      @matrix.all_items.should include("bar")
+      expect(@matrix.all_items).to include("bar")
       @matrix.delete_item!("bar")
-      @matrix.all_items.should_not include("bar")
+      expect(@matrix.all_items).not_to include("bar")
     end
   end
 
@@ -224,10 +224,10 @@ describe Predictor::InputMatrix do
     @matrix.add_set "item2", ["bar", "fnord", "shmoo", "snafu"]
     @matrix.add_set "item3", ["bar", "nada", "snafu"]
 
-    @matrix.send(:calculate_jaccard,
+    expect(@matrix.send(:calculate_jaccard,
       "bar",
       "snafu"
-    ).should == 2.0/3.0
+    )).to eq(2.0/3.0)
   end
 
 private

--- a/spec/predictor_spec.rb
+++ b/spec/predictor_spec.rb
@@ -4,12 +4,12 @@ describe Predictor do
 
   it "should store a redis connection" do
     Predictor.redis = "asd"
-    Predictor.redis.should == "asd"
+    expect(Predictor.redis).to eq("asd")
   end
 
   it "should raise an exception if unconfigured redis connection is accessed" do
     Predictor.redis = nil
-    lambda{ Predictor.redis }.should raise_error(/not configured/i)
+    expect{ Predictor.redis }.to raise_error(/not configured/i)
   end
 
 end


### PR DESCRIPTION
This conversion is done by Transpec 1.10.4 with the following command:
    transpec -f
- 77 conversions
  from: obj.should
    to: expect(obj).to
- 35 conversions
  from: == expected
    to: eq(expected)
- 16 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 15 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 1 conversion
  from: lambda { }.should_not
    to: expect { }.not_to
- 1 conversion
  from: lambda { }.should
    to: expect { }.to
