### PR TITLE
Changes to support Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+  - 2.0.0
+  - 2.1.2
+services:
+  - redis-server

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,6 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec


### PR DESCRIPTION
1. Add the RSpec task as the default Rake task
2. Add a .travis.yml file that enables Redis.

A repository owner will need to go to http://travis-ci.org and enable Travis for this repository to complete the process.
