### PR TITLE
Add a test with github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0]
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby ${{ matrix.ruby }}
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake


### PR DESCRIPTION
I wanted to switch from travis ci to github actions, so I added a workflow for testing github actions.

The documentation I referred to is as follows.
https://docs.github.com/ja/enterprise-server@2.22/actions/learn-github-actions/migrating-from-travis-ci-to-github-actions

Since no Ruby 2.0 images were provided for github actions, Ruby 2.0 was removed from the test.
(We consider Ruby 2.0 to be good because it has already reached EOL)

Instead, I added Ruby 3.0 to the test.

The `.travis.yml` will be removed in subsequent commits.