### PR TITLE
Made it possible to run tests on ubuntu-18.04 and ubuntu-20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,12 @@ on: [push, pull_request]
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-18.04, ubuntu-20.04]
         ruby: [2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0]
     services:
       redis:


### PR DESCRIPTION
Changed Ubuntu-latest to use Ubuntu-20.04 so that it can be tested beforehand.
https://github.com/actions/virtual-environments/issues/1816

I got the following warning, so I've made sure that two versions are tested.
![スクリーンショット 2021-02-13 14 42 24](https://user-images.githubusercontent.com/12161701/107842868-b8da3000-6e09-11eb-82b0-2599bd23745a.png)


Extended Security Maintenance (ESM) for Ubuntu 18.04 LTS will continue until 2024.
![スクリーンショット 2021-02-13 14 36 41](https://user-images.githubusercontent.com/12161701/107842751-e83c6d00-6e08-11eb-9244-e75ac348d393.png)
https://ubuntu.com/about/release-cycle