### PR TITLE
[change] Quit supporting ruby with eol

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
-        ruby: [2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, 3.0]
     services:
       redis:
         image: redis


### PR DESCRIPTION
Ruby 2.1 ~ 2.5 will no longer be supported because of eol

Please refer to the following URL for the EOL date for each version.
https://www.ruby-lang.org/en/downloads/branches/
<img width="229" alt="スクリーンショット 2021-04-08 17 34 54" src="https://user-images.githubusercontent.com/12161701/113994942-c0113d80-9890-11eb-8142-c6837252aee7.png">
